### PR TITLE
BUIL-2111: Instagram Basic Display API Deprecation Migration

### DIFF
--- a/lib/instagram_basic_display/auth.rb
+++ b/lib/instagram_basic_display/auth.rb
@@ -46,7 +46,7 @@ module InstagramBasicDisplay
     # @return [InstagramBasicDisplay::Response] a response object containing either the token or an error
     def short_lived_token(access_code:)
       response = Net::HTTP.post_form(
-        URI('https://api.instagram.com/oauth/access_token'),
+        URI('https://graph.instagram.com/oauth/access_token'),
         client_id: configuration.client_id,
         client_secret: configuration.client_secret,
         grant_type: 'authorization_code',

--- a/lib/instagram_basic_display/version.rb
+++ b/lib/instagram_basic_display/version.rb
@@ -15,6 +15,6 @@
 # limitations under the License.
 
 module InstagramBasicDisplay
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end
 


### PR DESCRIPTION
This PR prepares instagram basic api to cut over to the new instagram api